### PR TITLE
Cleanup of $timestamp, $diff, and $output vars. Initial testing scripts created

### DIFF
--- a/bin/check-cisco-configs.pl
+++ b/bin/check-cisco-configs.pl
@@ -44,21 +44,21 @@ if ( defined $devices ) {
 print "Date,ConfigStamp,Device,Platform,Policy,Result,Remediation config\n";
 
 # Open list of devices
-open FILE, '<',  "$devices" or die "Could not open $devices $!";
+open my $FILE, '<',  "$devices" or die "Could not open $devices $!";
 
-while (<FILE>) {
+while (<$FILE>) {
     $lines .= $_;
 }
 
-close FILE;
+close $FILE;
 
 foreach my $line ( split( /\n/, $lines ) ) {
     $line =~ s/\s+$//;
     $config = "";
 
     # Open device configuration files
-    open FILE, '<', "$cfgfiles/$line" or die "Could not open $line $!";
-    while (<FILE>) { $config .= $_ }
+    open $FILE, '<', "$cfgfiles/$line" or die "Could not open $line $!";
+    while (<$FILE>) { $config .= $_ }
     close $devices;
 
     # Check device platforms - IOS, NX-OS, IOS XR

--- a/bin/ioslib-call-testing.pl
+++ b/bin/ioslib-call-testing.pl
@@ -42,8 +42,7 @@ my ($file) = @ARGV;
 open my $FILE, '<', "$cfgfiles/$file" or die "file not found $file";
 
 # File timestamp
-my $timestamp = stat($FILE)->mtime;
-$timestamp = strftime "%m/%d/%y", localtime($timestamp);
+my $timestamp = strftime "%m/%d/%y", localtime(stat($FILE)->mtime);
 
 # Dump config into $config
 while (<$FILE>) { $config .= $_ }
@@ -56,67 +55,67 @@ my $output = "$file,";
 my @int_list = &interface_list($config);
 
 # Policy 04 - IOS Line AUX
-my $diff4 = &ios_config_nested_lines(
+$diff = &ios_config_nested_lines(
     &open_file("$ios_policy_dir/policy_04_IOS_Line_AUX"), $config );
-#if ( $diff4 =~ /does not exist/i ) {
-	#my $output4 = "PASS,";
-	#my $diff4   = "";
-	#}
-	#else {
-	# my $output4 = &pass_check($diff4);
-	#$diff4   = &strip_comments($diff4);
-	#}
-my $output4 = &pass_check($diff4);
-$diff4   = &strip_comments($diff4);
-print "$date,$timestamp,$file,IOS,04 - Line AUX,$output4$diff4\n";
+if ( $diff =~ /does not exist/i ) {
+	my $output = "PASS,you don't exist";
+	my $diff   = "";
+	print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
+	}
+else {
+	my $output = &pass_check($diff);
+	$diff   = &strip_comments($diff);
+	print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
+}
+# print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
 
 # Policy 08 - IOS DNS
-my $diff8 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_08_IOS_DNS"), $config );
-my $output8 = &pass_check($diff8);
-$diff8   = &strip_comments($diff8);
-print "$date,$timestamp,$file,IOS,08 - DNS,$output8$diff8\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,08 - DNS,$output$diff\n";
 
 # Policy 14 - IOS VStack
 if ( $config =~ /switch 1 provision/im ) {
-	my $diff14 = &ios_config_global_lines(
+	my $diff = &ios_config_global_lines(
         &open_file("$ios_policy_dir/policy_14_IOS_VStack"), $config );
-	my $output14 = &pass_check($diff14);
-	$diff14   = &strip_comments($diff14);
-	print "$date,$timestamp,$file,IOS,14 - VStack,$output14$diff14\n";
+	my $output = &pass_check($diff);
+	$diff   = &strip_comments($diff);
+	print "$date,$timestamp,$file,IOS,14 - VStack,$output$diff\n";
    }
 else {
-	my $diff14   = "";
-	my $output14 = "PASS,";
-	print "$date,$timestamp,$file,IOS,14 - VStack,$output14$diff14\n";
+	my $diff   = "";
+	my $output = "PASS,";
+	print "$date,$timestamp,$file,IOS,14 - VStack,$output$diff\n";
 	}
 
 # Policy 16 -IOS Boot System
-my $diff16 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_16_IOS_Boot_System"), $config );
-my $output16 = &pass_check($diff16);
-$diff16   = &strip_comments($diff16);
-print "$date,$timestamp,$file,IOS,16 - Boot System,$output16$diff16\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,16 - Boot System,$output$diff\n";
 
 # Policy 17 - IOS RCMD
-my $diff17 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_17_IOS_RCMD"), $config );
-my $output17 = &pass_check($diff17);
-$diff17   = &strip_comments($diff17);
-print "$date,$timestamp,$file,IOS,17 - RCMD,$output17$diff17\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,17 - RCMD,$output$diff\n";
 
 # Policy 18 - IOS Loopbacks
 if ( $config =~ /interface Loopback0/im && $file !~ /-sw/ ) {
-    my $diff18 = &ios_config_global_lines(
+    my $diff = &ios_config_global_lines(
         &open_file("$ios_policy_dir/policy_18_IOS_Loopback"), $config );
-    my $output18 = &pass_check($diff18);
-    $diff18   = &strip_comments($diff18);
-    print "$date,$timestamp,$file,IOS,18 - Loopback,$output18$diff18\n";
+    my $output = &pass_check($diff);
+    $diff   = &strip_comments($diff);
+    print "$date,$timestamp,$file,IOS,18 - Loopback,$output$diff\n";
 }
 else {
-    my $diff18   = "";
-    my $output18 = "PASS,";
-    print "$date,$timestamp,$file,IOS,18 - Loopback,$output18$diff18\n";
+    my $diff   = "";
+    my $output = "PASS,";
+    print "$date,$timestamp,$file,IOS,18 - Loopback,$output$diff\n";
 }
 
 #
@@ -125,10 +124,9 @@ sub strip_comments {
     my $new_config = shift or die;
 
     #separate the config commands from the comments in the new config
-    my $config = "";
+	my $config = "";
     foreach my $line ( split( /\n/, $new_config ) ) {
-        if ( $line =~ s/^\s*(!)/$1/ ) {
-
+		if ( $line =~ s/^\s*(!)/$1/ ) {
             #nothing
         }
         else {
@@ -137,8 +135,8 @@ sub strip_comments {
     }
 
     # This will strip SNMP Community strings from the report
-    $config =~ s{Alle5Gut}{<REDACTED>}g;
-    $config =~ s{\$3rvIceNoW!}{<REDACTED>}g;
+	$config =~ s{Alle5Gut}{<REDACTED>}g;
+	$config =~ s{\$3rvIceNoW!}{<REDACTED>}g;
     $config =~ tr{\n}{ };
-    return "$config";
+	return "$config";
 }

--- a/bin/ioslib-interface-testing.pl
+++ b/bin/ioslib-interface-testing.pl
@@ -1,0 +1,124 @@
+#!/usr/bin/perl
+
+# {{{ ---------------------------------------------------------------------- #
+#
+# Name:		ios-path-testing.pl
+# Purpose: This script is used for testing path settings and modules
+#				used to cleanup directory usage
+# Requirements: ioslib.pm
+#
+# Version: 0.0.1
+# Author: Kevin Bowen kevin.bowen@gmail.com
+#
+# Original source: policycheck_IOS-1.2.1.pl
+# Updated: 20191016
+#
+# }}} ---------------------------------------------------------------------- #
+
+use strict;
+use warnings;
+
+use Cwd;
+use English;
+use File::Basename;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use POSIX qw(strftime);
+use File::stat;
+
+use ioslib;
+
+my $abs_path = Cwd::abs_path($PROGRAM_NAME);
+my $date     = strftime "%m/%d/%y", localtime;
+my $dirname  = File::Basename::dirname($abs_path);
+my $cfgfiles = "$dirname/../devices";
+my $config   = '';
+my $diff = "";
+
+
+my $ios_policy_dir = "$dirname/../policies/ios";
+
+# Command line input
+# requires a filename. needs better error handling for failure.
+my ($file) = @ARGV;
+
+#Open config file
+open my $FILE, '<', "$cfgfiles/$file" or die "file not found $file";
+
+# File timestamp
+my $timestamp = strftime "%m/%d/%y", localtime(stat($FILE)->mtime);
+
+# Dump config into $config
+while (<$FILE>) { $config .= $_ }
+close $FILE;
+
+my $output = "$file,";
+
+my @int_list = &interface_list($config);
+foreach (@int_list) {
+	print "$_\n";
+}
+
+# looks like this is pulling entire config with nesting parts back not just 
+# interfaces as expected. Perhaps rename subroutine??
+my @int_array_nest = &int_array_nest($config);
+foreach (@int_array_nest) {
+	print "$_\n";
+}
+
+my @vlan_priorities = &vlan_priorities($config);
+foreach (@vlan_priorities) {
+	print "$_\n";
+}
+my @int_vlan_nest = &int_vlan_nest($config);
+foreach (@int_vlan_nest) {
+	print "$_\n";
+}
+# Policy 04 - IOS Line AUX
+# $diff = &ios_config_nested_lines(
+#     &open_file("$ios_policy_dir/policy_04_IOS_Line_AUX"), $config );
+# if ( $diff =~ /does not exist/i ) {
+# 	my $output = "PASS,you don't exist";
+# 	my $diff   = "";
+# 	print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
+# 	}
+# else {
+# 	my $output = &pass_check($diff);
+# 	$diff   = &strip_comments($diff);
+# 	print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
+# }
+
+# Policy 08 - IOS DNS
+# $diff = &ios_config_global_lines(
+#     &open_file("$ios_policy_dir/policy_08_IOS_DNS"), $config );
+# $output = &pass_check($diff);
+# $diff   = &strip_comments($diff);
+# print "$date,$timestamp,$file,IOS,08 - DNS,$output$diff\n";
+
+#
+sub strip_comments {
+
+    my $new_config = shift or die;
+
+    # Separate the config commands from the comments in the new config
+	# $new_config here appears to be using the policy templates.
+	# Perhaps rename the variable to reflect this?
+	my $config = "";
+    foreach my $line ( split( /\n/, $new_config ) ) {
+		if ( $line =~ s/^\s*(!)/$1/ ) {
+
+            # Do Nothing - Is this appropriate?
+        }
+        else {
+            $config .= "$line\n";
+        }
+    }
+
+    # This will strip SNMP Community strings from the report
+	# Consider pulling the strings from an ENV file to avoid
+	# storing sensitive data in VCS
+	$config =~ s{Alle5Gut}{<REDACTED>}g;
+	$config =~ s{\$3rvIceNoW!}{<REDACTED>}g;
+    $config =~ tr{\n}{ };
+	return "$config";
+}

--- a/bin/ioslib-path-testing.pl
+++ b/bin/ioslib-path-testing.pl
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+
+# {{{ ---------------------------------------------------------------------- #
+#
+# Name:		ios-path-testing.pl
+# Purpose: This script is used for testing path settings and modules
+#				used to cleanup directory usage
+# Requirements: ioslib.pm
+#
+# Version: 0.0.1
+# Author: Kevin Bowen kevin.bowen@gmail.com
+#
+# Original source: policycheck_IOS-1.2.1.pl
+# Updated: 20191016
+#
+# }}} ---------------------------------------------------------------------- #
+
+use strict;
+use warnings;
+
+use Cwd;
+use English;
+use File::Basename;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use POSIX qw(strftime);
+use File::stat;
+
+use ioslib;
+
+my $abs_path = Cwd::abs_path($PROGRAM_NAME);
+my $date     = strftime "%m/%d/%y", localtime;
+my $dirname  = File::Basename::dirname($abs_path);
+my $cfgfiles = "$dirname/../devices";
+my $config   = '';
+my $diff = "";
+my $ios_policy_dir = "$dirname/../policies/ios";
+
+print "========================\n";
+print "*** The following variables are used for path identification ***\n";
+print "========================\n";
+print "\$abs_path is:\n\t $abs_path\n";
+print "----------------\n";
+print "\$dirname is:\n\t $dirname\n";
+print "----------------\n";
+print "\$cfgfiles is:\n\t $cfgfiles\n";
+print "----------------\n";
+print "\$ios_policy_dir is:\n\t $ios_policy_dir\n";
+print "----------------\n";
+
+# Command line input
+# requires a filename. needs better error handling for failure.
+my ($file) = @ARGV;
+
+print "\@ARGV[0] is: $ARGV[0]\n";
+#Open config file
+open my $FILE, '<', "$cfgfiles/$file" or die "file not found $file $!";
+
+# File timestamp
+# Q: Can this be done cleaner? A: Why, YES! Indeed it can. Merge with
+# master.
+my $timestamp = strftime "%m/%d/%y", localtime(stat($FILE)->mtime);
+
+# Dump config into $config
+while (<$FILE>) { $config .= $_ }
+close $FILE;
+
+my $output = "$file,";
+
+# Policy 04 - IOS Line AUX
+#$diff = &ios_config_nested_lines(
+#    &open_file("$ios_policy_dir/policy_04_IOS_Line_AUX"), $config );
+#if ( $diff =~ /does not exist/i ) {
+#	my $output = "PASS,you don't exist";
+#	my $diff   = "";
+#	print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
+#	}
+#else {
+#	my $output = &pass_check($diff);
+#	$diff   = &strip_comments($diff);
+#	print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
+#}
+
+# Policy 08 - IOS DNS
+#$diff = &ios_config_global_lines(
+#    &open_file("$ios_policy_dir/policy_08_IOS_DNS"), $config );
+#$output = &pass_check($diff);
+#$diff   = &strip_comments($diff);
+#print "$date,$timestamp,$file,IOS,08 - DNS,$output$diff\n";

--- a/bin/policycheck_IOS-testing.pl
+++ b/bin/policycheck_IOS-testing.pl
@@ -1,18 +1,17 @@
 #!/usr/bin/perl
-
 # {{{ ---------------------------------------------------------------------- #
 #
-# Name:		policycheck_IOS-testing.pl
+# Name: smartsios_1.2.1.pl
 # Purpose: This script checks configurations in ../devices direction
 # for IOS v1.00 policy violations
 # Compatible:
 # Requirements: ioslib.pm
 #
-# Version: 0.0.1
+# Version: 1.2.1
 # Author: Kevin Bowen kevin.bowen@gmail.com
 #
 # Original source:
-# Updated: 20191014
+# Updated: 20190919
 #
 # }}} ---------------------------------------------------------------------- #
 
@@ -33,94 +32,238 @@ my $abs_path = Cwd::abs_path($PROGRAM_NAME);
 my $date     = strftime "%m/%d/%y", localtime;
 my $dirname  = File::Basename::dirname($abs_path);
 my $cfgfiles = "$dirname/../devices";
-my $config   = '';
-
+my $config;
+my $diff = "";
 my $ios_policy_dir = "$dirname/../policies/ios";
 
 #Command line input
 my ($file) = @ARGV;
 
 #Open config file
-open my $FILE, '<', "$cfgfiles/$file" or die "file not found $file";
+open my $FILE, '<', "$cfgfiles/$file" or die "file not found $file $!";
 
 # File timestamp
-my $timestamp = stat($FILE)->mtime;
-$timestamp = strftime "%m/%d/%y", localtime($timestamp);
+my $timestamp = strftime "%m/%d/%y", localtime(stat($FILE)->mtime);
 
 # Dump config into $config
 while (<$FILE>) { $config .= $_ }
 close $FILE;
 
-my $diff = "";
-
 my $output = "$file,";
 
-my @int_list = &interface_list($config);
+# Policy 01 - IOS AAA Configuration
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_01_IOS_AAA"), $config );
+$output = &pass_check($diff);
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,01 - AAA,$output$diff\n";
+
+# Policy 02 - IOS TACACS
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_02_IOS_TACACS"), $config );
+$output = &pass_check($diff);
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,02 - TACACS,$output$diff\n";
+
+# Policy 03 - IOS Line Console
+$diff = &ios_config_nested_lines(
+    &open_file("$ios_policy_dir/policy_03_IOS_Line_Console"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,03 - Line CONSOLE,$output$diff\n";
 
 # Policy 04 - IOS Line AUX
-my $diff4 = &ios_config_nested_lines(
+$diff = &ios_config_nested_lines(
     &open_file("$ios_policy_dir/policy_04_IOS_Line_AUX"), $config );
-#if ( $diff4 =~ /does not exist/i ) {
-	#my $output4 = "PASS,";
-	#my $diff4   = "";
-	#}
-	#else {
-	# my $output4 = &pass_check($diff4);
-	#$diff4   = &strip_comments($diff4);
-	#}
-my $output4 = &pass_check($diff4);
-$diff4   = &strip_comments($diff4);
-print "$date,$timestamp,$file,IOS,04 - Line AUX,$output4$diff4\n";
+if ( $diff =~ /does not exist/mi ) {
+    $output = "PASS,";
+    $diff  = "";
+}
+else {
+    $output = &pass_check($diff);
+    $diff  = &strip_comments($diff);
+}
+print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
+
+# Policy 05 - IOS Line VTY 0 4
+$diff = &ios_config_nested_lines(
+    &open_file("$ios_policy_dir/policy_05_IOS_Line_VTY1"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,05 - Line VTY1,$output$diff\n";
+
+# Policy 06 - IOS Line VTY 5 15
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_06_IOS_Line_VTY2"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,06 - Line VTY2,$output$diff\n";
+
+# Policy 07 - IOS NTP
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_07_IOS_NTP"), $config );
+$output = "PASS,";
+$diff =~ tr{\n}{ };
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,07 - NTP,$output$diff\n";
 
 # Policy 08 - IOS DNS
-my $diff8 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_08_IOS_DNS"), $config );
-my $output8 = &pass_check($diff8);
-$diff8   = &strip_comments($diff8);
-print "$date,$timestamp,$file,IOS,08 - DNS,$output8$diff8\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,08 - DNS,$output$diff\n";
+
+# Policy 09 - IOS SNMP ACL Configuration
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_09_IOS_SNMP_ACL"), $config );
+$output = &pass_check($diff);
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,09 - SNMP ACL,$output$diff\n";
+
+# Policy 10 - IOS SNMP Configuration
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_10_IOS_SNMP"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,10 - SNMP,$output$diff\n";
+
+# Policy 11 - IOS SNMP Identity information
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_11_IOS_SNMP_Identity"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,11 - SNMP Identity,$output$diff\n";
+
+# Policy 12 - IOS Banner
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_12_IOS_Banner"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,12 - Banner,$output$diff\n";
+
+# Policy 13 - IOS SSH
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_13_IOS_SSH"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,13 - SSH,$output$diff\n";
 
 # Policy 14 - IOS VStack
-# if ( $config =~ /switch 1 provision/i ) {
-my $diff14 = &ios_config_global_lines(
+if ( $config =~ /switch 1 provision/i ) {
+    $diff = &ios_config_global_lines(
         &open_file("$ios_policy_dir/policy_14_IOS_VStack"), $config );
-$diff14   = &strip_comments($diff14);
-my $output14 = &pass_check($diff14);
-   #}
-#else {
-	#my $diff14   = "";
-	#my $output14 = "PASS,";
-	#}
-print "$date,$timestamp,$file,IOS,14 - VStack,$output14$diff14\n";
+    $output = &pass_check($diff);
+    $diff  = &strip_comments($diff);
+	print "$date,$timestamp,$file,IOS,14 - VStack,$output$diff\n";
+}
+else {
+    $diff   = "";
+    $output = "PASS,";
+	print "$date,$timestamp,$file,IOS,14 - VStack,$output$diff\n";
+}
+
+# Policy 15 - IOS Basic Services
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_15_IOS_Basic_Services"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,15 - BASIC Services,$output$diff\n";
 
 # Policy 16 -IOS Boot System
-my $diff16 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_16_IOS_Boot_System"), $config );
-my $output16 = &pass_check($diff16);
-$diff16   = &strip_comments($diff16);
-print "$date,$timestamp,$file,IOS,16 - Boot System,$output16$diff16\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,16 - Boot System,$output$diff\n";
 
 # Policy 17 - IOS RCMD
-my $diff17 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_17_IOS_RCMD"), $config );
-my $output17 = &pass_check($diff17);
-$diff17   = &strip_comments($diff17);
-print "$date,$timestamp,$file,IOS,17 - RCMD,$output17$diff17\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,17 - RCMD,$output$diff\n";
 
 # Policy 18 - IOS Loopbacks
 if ( $config =~ /interface Loopback0/im && $file !~ /-sw/ ) {
-    my $diff18 = &ios_config_global_lines(
+    my $diff = &ios_config_global_lines(
         &open_file("$ios_policy_dir/policy_18_IOS_Loopback"), $config );
-    my $output18 = &pass_check($diff18);
-    $diff18   = &strip_comments($diff18);
-    print "$date,$timestamp,$file,IOS,18 - Loopback,$output18$diff18\n";
+    $output = &pass_check($diff);
+    $diff  = &strip_comments($diff);
+    print "$date,$timestamp,$file,IOS,18 - Loopback,$output$diff\n";
 }
 else {
-    my $diff18   = "";
-    my $output18 = "PASS,";
-    print "$date,$timestamp,$file,IOS,18 - Loopback,$output18$diff18\n";
+    my $diff  = "";
+    my $output = "PASS,";
+    print "$date,$timestamp,$file,IOS,18 - Loopback,$output$diff\n";
 }
 
-#
+# Policy 19 - IOS Interface Security
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_19_IOS_Interface_Security"), $config );
+$output .= &pass_check($diff);
+$output = "PASS,";
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,19 - Interface Security,$output$diff\n";
+
+# Policy 20 - IOS Rapid  ACL
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_20_IOS_Rapid_ACL"), $config );
+$output = "PASS,";
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,20 - Rapid ACL,$output$diff\n";
+
+# Policy 21 - IOS SNMP TRAP
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_21_IOS_SNMP_TRAP"), $config );
+$output = "PASS,";
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,21 - SNMP Trap,$output$diff\n";
+
+# Policy 22 - IOS Interface Description
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_22_IOS_Interface_Description"),
+    $config );
+$output = "PASS,";
+$diff = &strip_comments($diff);
+print
+    "$date,$timestamp,$file,IOS,22 - Interface Description,$output$diff\n";
+
+# Policy 23 - IOS IP Security
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_23_IOS_IP_Security"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,23 - IP SECURITY,$output$diff\n";
+
+# Policy 24 - IOS Logging
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_24_IOS_Logging"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,24 - LOGGING,$output$diff\n";
+
+# Policy 25 -IOS VTP
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_25_IOS_VTP"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,25 - VTP,$output$diff\n";
+
+# Policy 26 - IOS BPDUGuard
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_26_IOS_BPDUGuard"), $config );
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,26 - BPDUGUARD,$output$diff\n";
+
+# Policy 27 -IOS BPDUGuard Default
+$diff = &ios_config_global_lines(
+    &open_file("$ios_policy_dir/policy_27_IOS_BPDUGuard_Default"), $config );
+$output = &pass_check($diff);
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,27 - BPDUGUARD-DEFAULT,$output$diff\n";
+
 sub strip_comments {
 
     my $new_config = shift or die;

--- a/bin/policycheck_IOS_1.2.1.pl
+++ b/bin/policycheck_IOS_1.2.1.pl
@@ -15,7 +15,7 @@
 #
 # }}} ---------------------------------------------------------------------- #
 
-# use strict;
+use strict;
 use warnings;
 
 use Cwd;
@@ -33,241 +33,236 @@ my $date     = strftime "%m/%d/%y", localtime;
 my $dirname  = File::Basename::dirname($abs_path);
 my $cfgfiles = "$dirname/../devices";
 my $config;
-
+my $diff = "";
 my $ios_policy_dir = "$dirname/../policies/ios";
 
 #Command line input
 my ($file) = @ARGV;
 
 #Open config file
-open $file, "$cfgfiles/$file" or die "file not found $file";
+open my $FILE, '<', "$cfgfiles/$file" or die "file not found $file $!";
 
 # File timestamp
-my $timestamp = stat($file)->mtime;
-$timestamp = strftime "%m/%d/%y", localtime($timestamp);
+my $timestamp = strftime "%m/%d/%y", localtime(stat($FILE)->mtime);
 
 # Dump config into $config
-while (<$file>) { $config .= $_ }
-close $file;
-
-my $diff = "";
+while (<$FILE>) { $config .= $_ }
+close $FILE;
 
 my $output = "$file,";
 
-my @int_list = &interface_list($config);
-
 # Policy 01 - IOS AAA Configuration
-$diff1 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_01_IOS_AAA"), $config );
-$output1 = &pass_check($diff1);
-$diff1   = &strip_comments($diff1);
-print "$date,$timestamp,$file,IOS,01 - AAA,$output1$diff1\n";
+$output = &pass_check($diff);
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,01 - AAA,$output$diff\n";
 
 # Policy 02 - IOS TACACS
-$diff2 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_02_IOS_TACACS"), $config );
-$output2 = &pass_check($diff2);
-$diff2   = &strip_comments($diff2);
-print "$date,$timestamp,$file,IOS,02 - TACACS,$output2$diff2\n";
+$output = &pass_check($diff);
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,02 - TACACS,$output$diff\n";
 
 # Policy 03 - IOS Line Console
-$diff3 = &ios_config_nested_lines(
+$diff = &ios_config_nested_lines(
     &open_file("$ios_policy_dir/policy_03_IOS_Line_Console"), $config );
-$output3 = &pass_check($diff3);
-$diff3   = &strip_comments($diff3);
-print "$date,$timestamp,$file,IOS,03 - Line CONSOLE,$output3$diff3\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,03 - Line CONSOLE,$output$diff\n";
 
 # Policy 04 - IOS Line AUX
-$diff4 = &ios_config_nested_lines(
+$diff = &ios_config_nested_lines(
     &open_file("$ios_policy_dir/policy_04_IOS_Line_AUX"), $config );
-if ( $diff4 =~ /does not exist/mi ) {
-    $output4 = "PASS,";
-    $diff4   = "";
+if ( $diff =~ /does not exist/mi ) {
+    $output = "PASS,";
+    $diff  = "";
 }
 else {
-    $output4 = &pass_check($diff4);
-    $diff4   = &strip_comments($diff4);
+    $output = &pass_check($diff);
+    $diff  = &strip_comments($diff);
 }
-print "$date,$timestamp,$file,IOS,04 - Line AUX,$output4$diff4\n";
+print "$date,$timestamp,$file,IOS,04 - Line AUX,$output$diff\n";
 
 # Policy 05 - IOS Line VTY 0 4
-$diff5 = &ios_config_nested_lines(
+$diff = &ios_config_nested_lines(
     &open_file("$ios_policy_dir/policy_05_IOS_Line_VTY1"), $config );
-$output5 = &pass_check($diff5);
-$diff5   = &strip_comments($diff5);
-print "$date,$timestamp,$file,IOS,05 - Line VTY1,$output5$diff5\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,05 - Line VTY1,$output$diff\n";
 
 # Policy 06 - IOS Line VTY 5 15
-$diff6 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_06_IOS_Line_VTY2"), $config );
-$output6 = &pass_check($diff6);
-$diff6   = &strip_comments($diff6);
-print "$date,$timestamp,$file,IOS,06 - Line VTY2,$output6$diff6\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,06 - Line VTY2,$output$diff\n";
 
 # Policy 07 - IOS NTP
-$diff7 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_07_IOS_NTP"), $config );
-$output7 = "PASS,";
-$diff7 =~ tr{\n}{ };
-$diff7 = &strip_comments($diff7);
-print "$date,$timestamp,$file,IOS,07 - NTP,$output7$diff7\n";
+$output = "PASS,";
+$diff =~ tr{\n}{ };
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,07 - NTP,$output$diff\n";
 
 # Policy 08 - IOS DNS
-$diff8 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_08_IOS_DNS"), $config );
-$output8 = &pass_check($diff8);
-$diff8   = &strip_comments($diff8);
-print "$date,$timestamp,$file,IOS,08 - DNS,$output8$diff8\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,08 - DNS,$output$diff\n";
 
 # Policy 09 - IOS SNMP ACL Configuration
-$diff9 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_09_IOS_SNMP_ACL"), $config );
-$output9 = &pass_check($diff9);
-$diff9   = &strip_comments($diff9);
-print "$date,$timestamp,$file,IOS,09 - SNMP ACL,$output9$diff9\n";
+$output = &pass_check($diff);
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,09 - SNMP ACL,$output$diff\n";
 
 # Policy 10 - IOS SNMP Configuration
-$diff10 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_10_IOS_SNMP"), $config );
-$output10 = &pass_check($diff10);
-$diff10   = &strip_comments($diff10);
-print "$date,$timestamp,$file,IOS,10 - SNMP,$output10$diff10\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,10 - SNMP,$output$diff\n";
 
 # Policy 11 - IOS SNMP Identity information
-$diff11 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_11_IOS_SNMP_Identity"), $config );
-$output11 = &pass_check($diff11);
-$diff11   = &strip_comments($diff11);
-print "$date,$timestamp,$file,IOS,11 - SNMP Identity,$output11$diff11\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,11 - SNMP Identity,$output$diff\n";
 
 # Policy 12 - IOS Banner
-$diff12 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_12_IOS_Banner"), $config );
-$output12 = &pass_check($diff12);
-$diff12   = &strip_comments($diff12);
-print "$date,$timestamp,$file,IOS,12 - Banner,$output12$diff12\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,12 - Banner,$output$diff\n";
 
 # Policy 13 - IOS SSH
-$diff13 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_13_IOS_SSH"), $config );
-$output13 = &pass_check($diff13);
-$diff13   = &strip_comments($diff13);
-print "$date,$timestamp,$file,IOS,13 - SSH,$output13$diff13\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,13 - SSH,$output$diff\n";
 
 # Policy 14 - IOS VStack
 if ( $config =~ /switch 1 provision/i ) {
-    $diff14 = &ios_config_global_lines(
+    $diff = &ios_config_global_lines(
         &open_file("$ios_policy_dir/policy_14_IOS_VStack"), $config );
-    $diff14   = &strip_comments($diff14);
-    $output14 = &pass_check($diff14);
+    $output = &pass_check($diff);
+    $diff  = &strip_comments($diff);
+	print "$date,$timestamp,$file,IOS,14 - VStack,$output$diff\n";
 }
 else {
-    $diff14   = "";
-    $output14 = "PASS,";
+    $diff   = "";
+    $output = "PASS,";
+	print "$date,$timestamp,$file,IOS,14 - VStack,$output$diff\n";
 }
-print "$date,$timestamp,$file,IOS,14 - VStack,$output14$diff14\n";
 
 # Policy 15 - IOS Basic Services
-$diff15 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_15_IOS_Basic_Services"), $config );
-$output15 = &pass_check($diff15);
-$diff15   = &strip_comments($diff15);
-print "$date,$timestamp,$file,IOS,15 - BASIC Services,$output15$diff15\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,15 - BASIC Services,$output$diff\n";
 
 # Policy 16 -IOS Boot System
-$diff16 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_16_IOS_Boot_System"), $config );
-$output16 = &pass_check($diff16);
-$diff16   = &strip_comments($diff16);
-print "$date,$timestamp,$file,IOS,16 - Boot System,$output16$diff16\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,16 - Boot System,$output$diff\n";
 
 # Policy 17 - IOS RCMD
-$diff17 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_17_IOS_RCMD"), $config );
-$output17 = &pass_check($diff17);
-$diff17   = &strip_comments($diff17);
-print "$date,$timestamp,$file,IOS,17 - RCMD,$output17$diff17\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,17 - RCMD,$output$diff\n";
 
 # Policy 18 - IOS Loopbacks
 if ( $config =~ /interface Loopback0/im && $file !~ /-sw/ ) {
-    my $diff18 = &ios_config_global_lines(
+    my $diff = &ios_config_global_lines(
         &open_file("$ios_policy_dir/policy_18_IOS_Loopback"), $config );
-    $output18 = &pass_check($diff18);
-    $diff18   = &strip_comments($diff18);
-    print "$date,$timestamp,$file,IOS,18 - Loopback,$output18$diff18\n";
+    $output = &pass_check($diff);
+    $diff  = &strip_comments($diff);
+    print "$date,$timestamp,$file,IOS,18 - Loopback,$output$diff\n";
 }
 else {
-    my $diff18   = "";
-    my $output18 = "PASS,";
-    print "$date,$timestamp,$file,IOS,18 - Loopback,$output18$diff18\n";
+    my $diff  = "";
+    my $output = "PASS,";
+    print "$date,$timestamp,$file,IOS,18 - Loopback,$output$diff\n";
 }
 
 # Policy 19 - IOS Interface Security
-$diff19 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_19_IOS_Interface_Security"), $config );
-$output19 .= &pass_check($diff19);
-$output19 = "PASS,";
-$diff19   = &strip_comments($diff19);
-print "$date,$timestamp,$file,IOS,19 - Interface Security,$output19$diff19\n";
+$output .= &pass_check($diff);
+$output = "PASS,";
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,19 - Interface Security,$output$diff\n";
 
 # Policy 20 - IOS Rapid  ACL
-$diff20 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_20_IOS_Rapid_ACL"), $config );
-$output20 = "PASS,";
-$diff20   = &strip_comments($diff20);
-print "$date,$timestamp,$file,IOS,20 - Rapid ACL,$output20$diff20\n";
+$output = "PASS,";
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,20 - Rapid ACL,$output$diff\n";
 
 # Policy 21 - IOS SNMP TRAP
-$diff21 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_21_IOS_SNMP_TRAP"), $config );
-$output21 = "PASS,";
-$diff21   = &strip_comments($diff21);
-print "$date,$timestamp,$file,IOS,21 - SNMP Trap,$output21$diff21\n";
+$output = "PASS,";
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,21 - SNMP Trap,$output$diff\n";
 
 # Policy 22 - IOS Interface Description
-$diff22
-    = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_22_IOS_Interface_Description"),
     $config );
-$output22 = "PASS,";
-$diff22   = &strip_comments($diff22);
+$output = "PASS,";
+$diff = &strip_comments($diff);
 print
-    "$date,$timestamp,$file,IOS,22 - Interface Description,$output22$diff22\n";
+    "$date,$timestamp,$file,IOS,22 - Interface Description,$output$diff\n";
 
 # Policy 23 - IOS IP Security
-$diff23 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_23_IOS_IP_Security"), $config );
-$output23 = &pass_check($diff23);
-$diff23   = &strip_comments($diff23);
-print "$date,$timestamp,$file,IOS,23 - IP SECURITY,$output23$diff23\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,23 - IP SECURITY,$output$diff\n";
 
 # Policy 24 - IOS Logging
-$diff24 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_24_IOS_Logging"), $config );
-$output24 = &pass_check($diff24);
-$diff24   = &strip_comments($diff24);
-print "$date,$timestamp,$file,IOS,24 - LOGGING,$output24$diff24\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,24 - LOGGING,$output$diff\n";
 
 # Policy 25 -IOS VTP
-$diff25 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_25_IOS_VTP"), $config );
-$output25 = &pass_check($diff25);
-$diff25   = &strip_comments($diff25);
-print "$date,$timestamp,$file,IOS,25 - VTP,$output25$diff25\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,25 - VTP,$output$diff\n";
 
 # Policy 26 - IOS BPDUGuard
-$diff26 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_26_IOS_BPDUGuard"), $config );
-$output26 = &pass_check($diff26);
-$diff26   = &strip_comments($diff26);
-print "$date,$timestamp,$file,IOS,26 - BPDUGUARD,$output26$diff26\n";
+$output = &pass_check($diff);
+$diff  = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,26 - BPDUGUARD,$output$diff\n";
 
 # Policy 27 -IOS BPDUGuard Default
-$diff27 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$ios_policy_dir/policy_27_IOS_BPDUGuard_Default"), $config );
-$output27 = &pass_check($diff27);
-$diff27   = &strip_comments($diff27);
-print "$date,$timestamp,$file,IOS,27 - BPDUGUARD-DEFAULT,$output27$diff27\n";
+$output = &pass_check($diff);
+$diff = &strip_comments($diff);
+print "$date,$timestamp,$file,IOS,27 - BPDUGUARD-DEFAULT,$output$diff\n";
 
 sub strip_comments {
 

--- a/bin/policycheck_NX-OS-testing.pl
+++ b/bin/policycheck_NX-OS-testing.pl
@@ -1,22 +1,21 @@
 #!/usr/bin/perl
-
 # {{{ ----------------------------------------------------------------------- #
 #
-# Name:		policycheck_NX-OS-testing.pl
+# Name: policycheck_NX-OS_1.2.1.pl
 # Purpose: This script checks configurations in ../devices direction
 # for NX-OS v1.00 policy violations
 # Compatible:
 # Requirements:
 #
-# Version: 0.0.1
+# Version: 1.2.1
 # Author: Kevin Bowen kevin.bowen@gmail.com
 #
 # Original source:
-# Updated: 20191014
+# Updated: 20191016
 #
 # }}}----------------------------------------------------------------------- #
 
-# use strict;
+use strict;
 use warnings;
 
 use Cwd;
@@ -34,16 +33,16 @@ my $dirname         = File::Basename::dirname($abs_path);
 my $cfgfiles        = "$dirname/../devices";
 my $date            = strftime "%m/%d/%y", localtime;
 my $nxos_policy_dir = "$dirname/../policies/nx-os";
+my $config   = '';
 
 # Command line input
 my ($file) = @ARGV;
 
 # Open configuration files
-open $FILE, "$cfgfiles/$file" or die "file not found $file";
+open my $FILE, '<', "$cfgfiles/$file" or die "file not found $file $!";
 
 # File timestamp
-$timestamp = stat($FILE)->mtime;
-$timestamp = strftime "%m/%d/%y", localtime($timestamp);
+my $timestamp = strftime "%m/%d/%y", localtime(stat($FILE)->mtime);
 
 # Read configuration into $config
 while (<$FILE>) { $config .= $_ }
@@ -53,51 +52,209 @@ my $diff     = "";
 my $output   = "$file,";
 my @int_list = &interface_list($config);
 
+# Policy 01 - NX-OS AAA Configuration
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_01_NX-OS_AAA"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,01 - AAA,$output$diff\n";
+
+# Policy 02 - NX-OS TACACS Configuration
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_02_NX-OS_TACACS"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,02 - TACACS,$output$diff\n";
+
+# Policy 03 - NX-OS MGMT Interface
+$diff = &ios_config_nested_lines(
+    &open_file("$nxos_policy_dir/policy_03_NX-OS_MGMT_Interface"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,03 - MGMT Interface,$output$diff\n";
+
+# Policy 04 - NX-OS MGMT Default Route
+$diff = &ios_config_nested_lines(
+    &open_file("$nxos_policy_dir/policy_04_NX-OS_MGMT_Routing"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,04 - MGMT Routing,$output$diff\n";
+
+# Policy 05 - NX-OS NTP
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_05_NX-OS_NTP"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,05 - NTP,$output$diff\n";
+
+# Policy 06 - NX-OS NTPConf
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_06_NX-OS_NTPConf"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,06 - NTPConf,$output$diff\n";
+
+# Policy  07 - NX-OS MGMT NTP
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_07_NX-OS_MGMT_NTP"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,07 - MGMT NTP,$output$diff\n";
+
+# Policy 08 - NX-OS DNS
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_08_NX-OS_DNS"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,08 - DNS,$output$diff\n";
+
+# Policy 09 - NX-OS SNMP ACL
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_09_NX-OS_SNMP_ACL"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,09 - SNMP ACL,$output$diff\n";
+
+# Policy 10 - NX-OS SNMP
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_10_NX-OS_SNMP"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,10 - SNMP,$output$diff\n";
+
+# Policy 11 - NX-OS SNMP Identity
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_11_NX-OS_SNMP_Identity"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,11 - SNMP Identity,$output$diff\n";
+
+# Policy 12  - NX-OS Banner
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_12_NX-OS_Banner"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,12 - Banner,$output$diff\n";
+
+# Policy 13 - NX-OS SSH
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_13_NX-OS_SSH"), $config );
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,13 - SSH,$output$diff\n";
+
 # Policy 14 - NX-OS SNMPv3 Configuration
-$diff14 .= &ios_config_global_lines(
+$diff .= &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_14_NX-OS_SNMPv3"), $config );
-$output14 = &pass_check($diff14);
-$diff14   = &strip_comments($diff14);
-print "$date,$timestamp,$file,NX-OS,14 - SNMPv3,$output14$diff14\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,14 - SNMPv3,$output$diff\n";
+
+# Policy 15 - NX-OS Basic Services
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_15_NX-OS_Basic_Services"), $config );
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,15 - Basic Services,$output$diff\n";
+
+# Policy 16 - NX-OS Boot System
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_16_NX-OS_Boot_System"), $config );
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,16 - Boot System,$output$diff\n";
+
+# Policy 17 - NX-OS RCMD
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_17_NX-OS_RCMD"), $config );
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,17 - RCMD,$output$diff\n";
 
 # Policy 18 - NX-OS Loopback
-$diff18 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_18_NX-OS_Loopback"), $config );
 
 # Current batch of NX-OS do not use loopback. Ignore test.
-# $output18 = &pass_check($diff18);
-$output18 = "PASS,";
-$diff18   = &strip_comments($diff18);
-print "$date,$timestamp,$file,NX-OS,18 - Loopback,$output18$diff18\n";
+# $output = &pass_check($diff);
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,18 - Loopback,$output$diff\n";
+
+# Policy 19 - NX-OS IP Security
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_19_NX-OS_IP_Security"), $config );
+$output .= &pass_check($diff);
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,19 - IP Security,$output$diff\n";
+
+# Policy 20 - NX-OS Source Route
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_20_NX-OS_Source_Route"), $config );
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,20 - Source Route,$output$diff\n";
+
+# Policy 21 - NX-OS SNMP Trap
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_21_NX-OS_SNMP_TRAP"), $config );
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,21 - SNMP Trap,$output$diff\n";
 
 # Policy 22 - NX-OS Interface Description
-$diff22
+$diff
     = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_22_NX-OS_Interface_Description"),
     $config );
-$output22 = &pass_check($diff22);
-$diff22   = &strip_comments($diff22);
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
 print
-    "$date,$timestamp,$file,NX-OS,22 - Interface Description,$output22$diff22\n";
+    "$date,$timestamp,$file,NX-OS,22 - Interface Description,$output$diff\n";
 
 # Policy 23 - NX-OS CoPP Policy
-$diff23 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_23_NX-OS_CoPP"), $config );
 
-# $diff23 .= &ios_config_nested_lines(&open_file("$nxos_policy_dir/policy_23_NX-OS_Copp"),$config);
-$output23 = &pass_check($diff23);
-$diff23   = &strip_comments($diff23);
-print "$date,$timestamp,$file,NX-OS,23 - CoPP,$output23$diff23\n";
+# $diff .= &ios_config_nested_lines(&open_file("$nxos_policy_dir/policy_23_NX-OS_Copp"),$config);
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,23 - CoPP,$output$diff\n";
 
 # Policy 24 - NX-OS Logging
-# $diff24 = &ios_config_acls(&open_file("$nxos_policy_dir/policy_24"),$config);
-$diff24 = &ios_config_global_lines(
+# $diff = &ios_config_acls(&open_file("$nxos_policy_dir/policy_24"),$config);
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_24_NX-OS_Logging"), $config );
-$output24 = &pass_check($diff24);
-$diff24   = &strip_comments($diff24);
-print "$date,$timestamp,$file,NX-OS,24 - Logging,$output24$diff24\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,24 - Logging,$output$diff\n";
 
+# Policy 25 - NX-OS VTP
+# $diff = &ios_config_all_interfaces(&open_file("$nxos_policy_dir/policy25"),$config,@int_list);
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_25_NX-OS_VTP"), $config );
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,25 - VTP,$output$diff\n";
 
+# Policy 26 - NX-OS BPDUGuard
+# $diff = &ios_config_all_interfaces(&open_file("$nxos_policy_dir/policy_26_NX-OS_BPDUGuard"),$config,@int_list);
+$diff = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_26_NX-OS_BPDUGuard"), $config );
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,26 - BPDUGuard,$output$diff\n";
+
+# Policy 27 - NX-OS BPDUGuard Default
+$diff
+    = &ios_config_global_lines(
+    &open_file("$nxos_policy_dir/policy_27_NX-OS_BPDUGuard_Default"),
+    $config );
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print
+    "$date,$timestamp,$file,NX-OS,27 - BPDUGuard Default,$output$diff\n";
 
 sub strip_comments {
 

--- a/bin/policycheck_NX-OS_1.2.1.pl
+++ b/bin/policycheck_NX-OS_1.2.1.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 # {{{ ----------------------------------------------------------------------- #
 #
-# Name: smartsnx_1.2.1.pl
+# Name: policycheck_NX-OS_1.2.1.pl
 # Purpose: This script checks configurations in ../devices direction
 # for NX-OS v1.00 policy violations
 # Compatible:
@@ -11,11 +11,11 @@
 # Author: Kevin Bowen kevin.bowen@gmail.com
 #
 # Original source:
-# Updated: 20190919
+# Updated: 20191016
 #
 # }}}----------------------------------------------------------------------- #
 
-# use strict;
+use strict;
 use warnings;
 
 use Cwd;
@@ -33,16 +33,16 @@ my $dirname         = File::Basename::dirname($abs_path);
 my $cfgfiles        = "$dirname/../devices";
 my $date            = strftime "%m/%d/%y", localtime;
 my $nxos_policy_dir = "$dirname/../policies/nx-os";
+my $config   = '';
 
 # Command line input
 my ($file) = @ARGV;
 
 # Open configuration files
-open $FILE, "$cfgfiles/$file" or die "file not found $file";
+open my $FILE, '<', "$cfgfiles/$file" or die "file not found $file $!";
 
 # File timestamp
-$timestamp = stat($FILE)->mtime;
-$timestamp = strftime "%m/%d/%y", localtime($timestamp);
+my $timestamp = strftime "%m/%d/%y", localtime(stat($FILE)->mtime);
 
 # Read configuration into $config
 while (<$FILE>) { $config .= $_ }
@@ -53,208 +53,208 @@ my $output   = "$file,";
 my @int_list = &interface_list($config);
 
 # Policy 01 - NX-OS AAA Configuration
-$diff1 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_01_NX-OS_AAA"), $config );
-$output1 = &pass_check($diff1);
-$diff1   = &strip_comments($diff1);
-print "$date,$timestamp,$file,NX-OS,01 - AAA,$output1$diff1\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,01 - AAA,$output$diff\n";
 
 # Policy 02 - NX-OS TACACS Configuration
-$diff2 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_02_NX-OS_TACACS"), $config );
-$output2 = &pass_check($diff2);
-$diff2   = &strip_comments($diff2);
-print "$date,$timestamp,$file,NX-OS,02 - TACACS,$output2$diff2\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,02 - TACACS,$output$diff\n";
 
 # Policy 03 - NX-OS MGMT Interface
-$diff3 = &ios_config_nested_lines(
+$diff = &ios_config_nested_lines(
     &open_file("$nxos_policy_dir/policy_03_NX-OS_MGMT_Interface"), $config );
-$output3 = &pass_check($diff3);
-$diff3   = &strip_comments($diff3);
-print "$date,$timestamp,$file,NX-OS,03 - MGMT Interface,$output3$diff3\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,03 - MGMT Interface,$output$diff\n";
 
 # Policy 04 - NX-OS MGMT Default Route
-$diff4 = &ios_config_nested_lines(
+$diff = &ios_config_nested_lines(
     &open_file("$nxos_policy_dir/policy_04_NX-OS_MGMT_Routing"), $config );
-$output4 = &pass_check($diff4);
-$diff4   = &strip_comments($diff4);
-print "$date,$timestamp,$file,NX-OS,04 - MGMT Routing,$output4$diff4\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,04 - MGMT Routing,$output$diff\n";
 
 # Policy 05 - NX-OS NTP
-$diff5 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_05_NX-OS_NTP"), $config );
-$output5 = &pass_check($diff5);
-$diff5   = &strip_comments($diff5);
-print "$date,$timestamp,$file,NX-OS,05 - NTP,$output5$diff5\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,05 - NTP,$output$diff\n";
 
 # Policy 06 - NX-OS NTPConf
-$diff6 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_06_NX-OS_NTPConf"), $config );
-$output6 = &pass_check($diff6);
-$diff6   = &strip_comments($diff6);
-print "$date,$timestamp,$file,NX-OS,06 - NTPConf,$output6$diff6\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,06 - NTPConf,$output$diff\n";
 
 # Policy  07 - NX-OS MGMT NTP
-$diff7 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_07_NX-OS_MGMT_NTP"), $config );
-$output7 = &pass_check($diff7);
-$diff7   = &strip_comments($diff7);
-print "$date,$timestamp,$file,NX-OS,07 - MGMT NTP,$output7$diff7\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,07 - MGMT NTP,$output$diff\n";
 
 # Policy 08 - NX-OS DNS
-$diff8 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_08_NX-OS_DNS"), $config );
-$output8 = &pass_check($diff8);
-$diff8   = &strip_comments($diff8);
-print "$date,$timestamp,$file,NX-OS,08 - DNS,$output8$diff8\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,08 - DNS,$output$diff\n";
 
 # Policy 09 - NX-OS SNMP ACL
-$diff9 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_09_NX-OS_SNMP_ACL"), $config );
-$output9 = &pass_check($diff9);
-$diff9   = &strip_comments($diff9);
-print "$date,$timestamp,$file,NX-OS,09 - SNMP ACL,$output9$diff9\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,09 - SNMP ACL,$output$diff\n";
 
 # Policy 10 - NX-OS SNMP
-$diff10 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_10_NX-OS_SNMP"), $config );
-$output10 = &pass_check($diff10);
-$diff10   = &strip_comments($diff10);
-print "$date,$timestamp,$file,NX-OS,10 - SNMP,$output10$diff10\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,10 - SNMP,$output$diff\n";
 
 # Policy 11 - NX-OS SNMP Identity
-$diff11 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_11_NX-OS_SNMP_Identity"), $config );
-$output11 = &pass_check($diff11);
-$diff11   = &strip_comments($diff11);
-print "$date,$timestamp,$file,NX-OS,11 - SNMP Identity,$output11$diff11\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,11 - SNMP Identity,$output$diff\n";
 
 # Policy 12  - NX-OS Banner
-$diff12 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_12_NX-OS_Banner"), $config );
-$output12 = &pass_check($diff12);
-$diff12   = &strip_comments($diff12);
-print "$date,$timestamp,$file,NX-OS,12 - Banner,$output12$diff12\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,12 - Banner,$output$diff\n";
 
 # Policy 13 - NX-OS SSH
-$diff13 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_13_NX-OS_SSH"), $config );
-$output13 = &pass_check($diff13);
-$diff13   = &strip_comments($diff13);
-print "$date,$timestamp,$file,NX-OS,13 - SSH,$output13$diff13\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,13 - SSH,$output$diff\n";
 
 # Policy 14 - NX-OS SNMPv3 Configuration
-$diff14 .= &ios_config_global_lines(
+$diff .= &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_14_NX-OS_SNMPv3"), $config );
-$output14 = &pass_check($diff14);
-$diff14   = &strip_comments($diff14);
-print "$date,$timestamp,$file,NX-OS,14 - SNMPv3,$output14$diff14\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,14 - SNMPv3,$output$diff\n";
 
 # Policy 15 - NX-OS Basic Services
-$diff15 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_15_NX-OS_Basic_Services"), $config );
-$output15 = "PASS,";
-$diff15   = &strip_comments($diff15);
-print "$date,$timestamp,$file,NX-OS,15 - Basic Services,$output15$diff15\n";
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,15 - Basic Services,$output$diff\n";
 
 # Policy 16 - NX-OS Boot System
-$diff16 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_16_NX-OS_Boot_System"), $config );
-$output16 = "PASS,";
-$diff16   = &strip_comments($diff16);
-print "$date,$timestamp,$file,NX-OS,16 - Boot System,$output16$diff16\n";
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,16 - Boot System,$output$diff\n";
 
 # Policy 17 - NX-OS RCMD
-$diff17 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_17_NX-OS_RCMD"), $config );
-$output17 = "PASS,";
-$diff17   = &strip_comments($diff17);
-print "$date,$timestamp,$file,NX-OS,17 - RCMD,$output17$diff17\n";
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,17 - RCMD,$output$diff\n";
 
 # Policy 18 - NX-OS Loopback
-$diff18 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_18_NX-OS_Loopback"), $config );
 
 # Current batch of NX-OS do not use loopback. Ignore test.
-# $output18 = &pass_check($diff18);
-$output18 = "PASS,";
-$diff18   = &strip_comments($diff18);
-print "$date,$timestamp,$file,NX-OS,18 - Loopback,$output18$diff18\n";
+# $output = &pass_check($diff);
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,18 - Loopback,$output$diff\n";
 
 # Policy 19 - NX-OS IP Security
-$diff19 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_19_NX-OS_IP_Security"), $config );
-$output19 .= &pass_check($diff19);
-$output19 = "PASS,";
-$diff19   = &strip_comments($diff19);
-print "$date,$timestamp,$file,NX-OS,19 - IP Security,$output19$diff19\n";
+$output .= &pass_check($diff);
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,19 - IP Security,$output$diff\n";
 
 # Policy 20 - NX-OS Source Route
-$diff20 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_20_NX-OS_Source_Route"), $config );
-$output20 = "PASS,";
-$diff20   = &strip_comments($diff20);
-print "$date,$timestamp,$file,NX-OS,20 - Source Route,$output20$diff20\n";
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,20 - Source Route,$output$diff\n";
 
 # Policy 21 - NX-OS SNMP Trap
-$diff21 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_21_NX-OS_SNMP_TRAP"), $config );
-$output21 = "PASS,";
-$diff21   = &strip_comments($diff21);
-print "$date,$timestamp,$file,NX-OS,21 - SNMP Trap,$output21$diff21\n";
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,21 - SNMP Trap,$output$diff\n";
 
 # Policy 22 - NX-OS Interface Description
-$diff22
+$diff
     = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_22_NX-OS_Interface_Description"),
     $config );
-$output22 = &pass_check($diff22);
-$diff22   = &strip_comments($diff22);
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
 print
-    "$date,$timestamp,$file,NX-OS,22 - Interface Description,$output22$diff22\n";
+    "$date,$timestamp,$file,NX-OS,22 - Interface Description,$output$diff\n";
 
 # Policy 23 - NX-OS CoPP Policy
-$diff23 = &ios_config_global_lines(
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_23_NX-OS_CoPP"), $config );
 
-# $diff23 .= &ios_config_nested_lines(&open_file("$nxos_policy_dir/policy_23_NX-OS_Copp"),$config);
-$output23 = &pass_check($diff23);
-$diff23   = &strip_comments($diff23);
-print "$date,$timestamp,$file,NX-OS,23 - CoPP,$output23$diff23\n";
+# $diff .= &ios_config_nested_lines(&open_file("$nxos_policy_dir/policy_23_NX-OS_Copp"),$config);
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,23 - CoPP,$output$diff\n";
 
 # Policy 24 - NX-OS Logging
-# $diff24 = &ios_config_acls(&open_file("$nxos_policy_dir/policy_24"),$config);
-$diff24 = &ios_config_global_lines(
+# $diff = &ios_config_acls(&open_file("$nxos_policy_dir/policy_24"),$config);
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_24_NX-OS_Logging"), $config );
-$output24 = &pass_check($diff24);
-$diff24   = &strip_comments($diff24);
-print "$date,$timestamp,$file,NX-OS,24 - Logging,$output24$diff24\n";
+$output = &pass_check($diff);
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,24 - Logging,$output$diff\n";
 
 # Policy 25 - NX-OS VTP
-# $diff25 = &ios_config_all_interfaces(&open_file("$nxos_policy_dir/policy25"),$config,@int_list);
-$diff25 = &ios_config_global_lines(
+# $diff = &ios_config_all_interfaces(&open_file("$nxos_policy_dir/policy25"),$config,@int_list);
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_25_NX-OS_VTP"), $config );
-$output25 = "PASS,";
-$diff25   = &strip_comments($diff25);
-print "$date,$timestamp,$file,NX-OS,25 - VTP,$output25$diff25\n";
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,25 - VTP,$output$diff\n";
 
 # Policy 26 - NX-OS BPDUGuard
-# $diff26 = &ios_config_all_interfaces(&open_file("$nxos_policy_dir/policy_26_NX-OS_BPDUGuard"),$config,@int_list);
-$diff26 = &ios_config_global_lines(
+# $diff = &ios_config_all_interfaces(&open_file("$nxos_policy_dir/policy_26_NX-OS_BPDUGuard"),$config,@int_list);
+$diff = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_26_NX-OS_BPDUGuard"), $config );
-$output26 = "PASS,";
-$diff26   = &strip_comments($diff26);
-print "$date,$timestamp,$file,NX-OS,26 - BPDUGuard,$output26$diff26\n";
+$output = "PASS,";
+$diff   = &strip_comments($diff);
+print "$date,$timestamp,$file,NX-OS,26 - BPDUGuard,$output$diff\n";
 
 # Policy 27 - NX-OS BPDUGuard Default
-$diff27
+$diff
     = &ios_config_global_lines(
     &open_file("$nxos_policy_dir/policy_27_NX-OS_BPDUGuard_Default"),
     $config );
-$output27 = "PASS,";
-$diff27   = &strip_comments($diff27);
+$output = "PASS,";
+$diff   = &strip_comments($diff);
 print
-    "$date,$timestamp,$file,NX-OS,27 - BPDUGuard Default,$output27$diff27\n";
+    "$date,$timestamp,$file,NX-OS,27 - BPDUGuard Default,$output$diff\n";
 
 sub strip_comments {
 

--- a/lib/ioslib.pm.testing
+++ b/lib/ioslib.pm.testing
@@ -1,0 +1,492 @@
+#!/usr/bin/perl
+
+# {{{ ---------------------------------------------------------------------- #
+#
+# Name: ioslib.pl
+# Purpose: This library is used for parsing Cisco device configs
+# Compatible:
+# Requirements:
+#
+# Version: 1.0.1
+# Author: Kevin Bowen kevin.bowen@gmail.com
+#
+# Original source:
+# Updated: 20190922
+#
+# }}}----------------------------------------------------------------------- #
+
+package ioslib;
+use strict;
+use warnings;
+use Exporter;
+our @ISA    = qw( Exporter );
+our @EXPORT = qw(
+    ios_config_global_lines
+    ios_config_nested_lines
+    config_lines
+    nest nest_mismatch
+    int_array_nest
+    vlan_priorities
+    int_vlan_nest
+    open_file
+    pass_check
+    interface_list
+    ios_config_all_interfaces
+);
+
+sub ios_config_global_lines {
+
+    # Usage:
+    # $config_delta = &ios_config_global_lines($new_config, $running_config)
+    # Read input from new config and init output config delta
+    # my $new_config = shift or return "";
+
+    my $new_config     = shift or die;
+    my $running_config = shift or die;
+    my $config_delta   = "";
+
+	# testing the removal of comments from the .cfg file
+	# AKA the $running_config
+	# my ( $trace, $residue ) = ( "", "" );
+	# foreach my $line ( split( /\n/, $running_config ) ) {
+	#    if ( $line =~ s/^\s*(!)/$1/ ) {
+	#        $residue .= "$line\n";
+			# print $residue,"\n";
+	#   }
+	#    elsif ( $line =~ s/^\s*(\S)/$1/ ) {
+	#        $trace .= "$line\n";
+	#    }
+	#}
+	# Separate the config commands from the comments in the new config
+	# $new_config is pulled from the policy file
+    my ( $config, $comments ) = ( "", "" );
+    foreach my $line ( split( /\n/, $new_config ) ) {
+        if ( $line =~ s/^\s*(!)/$1/ ) {
+            $comments .= "$line\n";
+			# print $comments,"\n";
+        }
+        elsif ( $line =~ s/^\s*(\S)/$1/ ) {
+            $config .= "$line\n";
+        }
+    }
+
+    # Set output config using common configurator config_global function
+	# $config_delta = &config_lines( $trace, $config );
+	$config_delta = &config_lines( $running_config, $config );
+
+    # Comment if config lines were all matched
+    if ($config_delta) {
+        $config_delta = "! FAIL mismatch config\n" . $config_delta . "\n";
+    }
+    else {
+        $config_delta = "! PASS matched config\n";
+    }
+
+    # $config_delta = "! configurator matched global config commands\n"
+    #	if not $config_delta;
+
+    # Prepend comments to config delta
+	# $config_delta = $comments . $config_delta;
+
+    # Finished ios_config_global_lines
+    chomp $config_delta;
+    return "$config_delta\n";
+}
+
+sub ios_config_nested_lines {
+
+    # $config_delta = &ios_config_nested_lines($new_config, $running_config)
+
+    # Read inputs and init output config delta
+    my $new_config    = shift;
+    my $nested_config = shift or return "";
+    $nested_config = "" if not defined $nested_config;
+    my $config_delta = "";
+
+    # Separate the config commands from the comments in the new config
+    my ( $nested_first_line, $config, $comments ) = ( "", "", "" );
+    foreach my $line ( split( /\n/, $new_config ) ) {
+        if ( $line =~ s/^\s*(!)/$1/ ) {
+            $comments .= "$line\n";
+        }
+        elsif ( not $nested_first_line and $line =~ s/^\s*(\S)/$1/ ) {
+            $nested_first_line = $line;
+        }
+        elsif ( $line =~ s/^\s*(\S)/$1/ ) {
+            $config .= "$line\n";
+        }
+    }
+
+    # Set output config using common configurator config_global function
+    # Remove leading spaces, so it looks like global config for config_lines
+    $nested_config =~ s/^\s*//mg;
+    $config_delta = &config_lines( $nested_config, $config );
+
+    # Comment if config lines were all matched or not
+    if ($config_delta) {
+        $config_delta = "! FAIL mismatch config\n" . $config_delta . "\n";
+    }
+    else {
+        $config_delta = "$comments ! PASS matched config\n";
+        return $config_delta;
+    }
+
+    if ( $nested_config !~ /^$nested_first_line/m ) {
+        $config_delta = "$comments ! PASS not applicable\n";
+        return $config_delta;
+    }
+
+    # Prepend config delta commands with nested first line and comments
+    $config_delta =~ s/^/ /mg;
+    $config_delta = "" if $config_delta !~ /\S/;
+    $config_delta = "$nested_first_line\n$config_delta" if $config_delta;
+    $config_delta = $comments . $config_delta;
+
+    # Finished &ios_config_nested_lines
+    chomp $config_delta;
+    return "$config_delta\n";
+}
+
+sub config_lines {
+
+    # $config_delta = &config_lines($config_old, $config_new)
+    # Purpose: Match $config_new to $config_old and set $config_delta
+    # $config_new lines missing from $config_old are added to $config_delta
+    # $config_new lines in format '+no /^regex/' can no-out $config_old lines
+    # $config_delta will be null if no changes are required
+
+    # Read inputs and init output config delta
+    my ( $config_old, $config_new ) = @_;
+    return "" if not defined $config_new;
+    my $config_delta = "";
+
+   # Loop through lines of new config
+   # Strip leading/trailing spaces and convert multiple spaces to single space
+    foreach my $line_new ( split( /\n/, $config_new ) ) {
+        $line_new =~ s/(^\s+|\s+$)//g;
+        $line_new =~ s/\s\s+/ /g;
+
+        next if $line_new !~ /\S/;
+
+        # Set flag if $config_new is spotted in $config_old
+        my $config_matched = 0;
+
+        # Set regex to match for +no lines, ensure no trailing letters
+        my $regex = "";
+        $regex = $1 if $line_new =~ /^\+no\s+\/(.+)\/\s*$/;
+        die "invalid regex trailing letters '$line_new'\n"
+            if $line_new =~ /^\+no\s+\/(.+)\/\w+\s*$/;
+
+        # Set regex2 to partial match for ~ lines
+        if ( $line_new =~ /\~\s+\/(.+)\// ) {
+
+            my $regex2 = $1;
+
+            # Add a comment if partial match is not found
+            if ( $config_old !~ /$regex2/m ) {
+                $config_delta .= "$regex2 <user input>";
+                return $config_delta;
+            }
+            else {
+                return "";
+            }
+        }
+
+        # Loop through existing config lines
+        # Only process lines with no leading spaces, skip comments
+        # Strip trailing spaces and convert multiple spaces to a single space
+        foreach my $line_old ( split( /\n/, $config_old ) ) {
+            next if $line_old !~ /^\S/;
+            $line_old         =~ s/\s+$//;
+            $line_old         =~ s/\s\s+/ /g;
+
+            # No-out old line in config delta if '+no /regex/' matches
+            # Don't no-out lines that we are adding in new config
+            if ( $regex and $line_old =~ /$regex/ ) {
+                next if $config_new =~ /^\s*\Q$line_old\E\s*$/m;
+                $config_delta .= "no $line_old\n";
+
+                # Set flag true if we found an old line matching the new line
+            }
+            elsif ( $line_new eq $line_old ) {
+                $config_matched = 1;
+            }
+
+            # Finish looping through global config lines
+        }
+
+        # Append new line to config delta if no '+no /regex/' and not matched
+        $config_delta .= "$line_new\n" if not $regex and not $config_matched;
+
+        # Finished looping through lines of new config
+    }
+
+    # Clean up end of config delta
+    $config_delta =~ s/\s+$//;
+    chomp($config_delta);
+
+    # $config_delta .= "\n";
+
+    # Finished @config_lines
+    return $config_delta;
+}
+
+sub nest {
+
+    # $nest = &nest($running_config, $line)
+    # Purpose: return $nest match in $running_config for $line
+    # $nest will contain $line and any following indented lines
+    # $line must have no leading spaces in $config
+    # $nest will be null if no matching $line was found in $config
+    # $nest tailing spaces removed and multiple spaces converted to single
+
+    # Set nest from running config matching line
+    my ( $config, $line ) = @_;
+    return "" if not defined $config;
+    return "" if not defined $line;
+
+    # Parse $nest for $config when $line matches
+    $line =~ s/^(\s+|\s+$)//g;
+    $line =~ s/\s\s+/ /g;
+    my $nest   = "";
+    my $sh_run = $Configurator::Common::d->{ios_sh_run};
+    foreach my $cfg_line ( split( /\n/, $sh_run ) ) {
+        $cfg_line =~ s/\s+$//;
+        $cfg_line =~ s/\s\s+/ /g;
+        if ( not $nest ) {
+            if ( $cfg_line eq $line ) {
+                $nest = "$line\n";
+            }
+            else {
+                next;
+            }
+        }
+        elsif ( $cfg_line =~ /^\S/ ) {
+            last;
+        }
+        else {
+            $nest .= "$cfg_line\n";
+        }
+    }
+
+    # Finished nest function
+    return $nest;
+}
+
+sub nest_mismatch {
+
+    # $mismatch = &nest_mismatch($nest_old, $nest_new)
+    # Purpose: See if $nest_old and $nest_new are exact matches
+    # $mismatch: set null for exact match, otherwise set "! mismatch hint\n"
+    # Note: the smart_config_line_mismatch is used for line comparisons
+
+    # Read inputs
+    my $nest_old = shift or return "! show run config nest missing\n";
+    my $nest_new = shift or return "! template config nest missing\n";
+
+    # Initialize output match flag
+    my $mismatch = "";
+
+    # Make list of old nest lines, used for comparison
+    my @old_lines = ();
+    foreach my $line ( split( /\n/, $nest_old ) ) {
+        next if $line !~ /\S/ or $line =~ /^\s*!/;
+        next if $line =~ /^\s*remark/;
+        $line =~ s/(^\s+|\s+$)//g;
+        $line =~ s/\s\s+/ /g;
+        push @old_lines, $line;
+    }
+
+    # Are we sure that we want to continue always skipping remarks in config?
+    # the above/below old/new nest line loops now skip remarks
+    # new nest loop below has duplicate trim regex, could be deleted
+    # was this done to eliminate hits on ACL remarks in audit reports?
+    # seems were few devices with an ios problem, preserving old remark
+    # don't other systems/projects/users sometimes key off remarks?
+    # maybe make skipping remarks a command line option in this script
+
+    # Make list of new nest lines, used for comparison
+    my @new_lines = ();
+    foreach my $line ( split( /\n/, $nest_new ) ) {
+        next if $line !~ /\S/ or $line =~ /^\s*!/;
+        next if $line =~ /^\s*remark/;
+        $line =~ s/(^\s+|\s+$)//g;
+        $line =~ s/(^\s+|\s+$)//g;
+        $line =~ s/\s\s+/ /g;
+        push @new_lines, $line;
+    }
+
+    # Grab first input config line
+    my $old_line = shift @old_lines;
+
+    # Warn if any old nest lines are not matched with new nest lines
+    foreach my $new_line (@new_lines) {
+
+        # Mismatch if new line is missing from old
+        if ( not defined $old_line ) {
+            $new_line =~ s/^\s+//;
+            $mismatch .= "! show run config missing this nest\n";
+            last;
+        }
+
+        # Mismatch if new and old lines are different
+        if ( $old_line ne $new_line ) {
+            $new_line =~ s/^\s+//;
+            $old_line =~ s/^\s+//;
+            $mismatch .= "! show run config mismatch old: $old_line\n";
+            $mismatch .= "! template config mismatch new: $new_line\n";
+            last;
+        }
+
+        # Config line and regex line matched, get next input config line
+        $old_line = shift @old_lines;
+
+        # Continue looping through new nest lines
+    }
+
+    # Check if old lines are left after checking new lines
+    if ( not $mismatch and defined $old_line ) {
+        $old_line =~ s/^\s+//;
+        $mismatch .= "! show run config extra: $old_line\n";
+    }
+
+    # Finished nest_mismatch function
+    return $mismatch;
+}
+
+sub int_array_nest {
+
+    my $running_config = shift or die;
+
+    # Store all nesting from running config separately
+    my $nest = "";
+    my %int;
+    foreach my $line ( split( /\n/, $running_config ) ) {
+        $line =~ s/\s+$//;
+        if ( $line =~ /^\S/ ) {
+            $nest = $line;
+            next;
+        }
+        $int{$nest} .= "$line\n"
+            if $nest ne "";
+    }
+
+    return %int;
+}
+
+sub vlan_priorities {
+    my @myvlans;
+    my $myprio;
+    my %priority;
+
+    my $running_config = shift or die;
+    foreach my $line ( split( /\n/, $running_config ) ) {
+        if ( $line =~ /tree vlan ([\d\-\,]+) priority (\d+)/ ) {
+            @myvlans = &_list_array($1);
+            $myprio  = $2;
+
+            foreach (@myvlans) {
+                $priority{$_} = $myprio;
+            }
+        }
+    }
+    return %priority;
+}
+
+sub _list_array {
+    my $list = shift or die;
+    my $vlan;
+    my $i;
+    my @vlarray;
+    foreach my $vlan ( split( /\,/, $list ) ) {
+        if ( $vlan =~ /^\d+$/ ) {
+            push( @vlarray, $vlan );
+        }
+        elsif ( $vlan =~ /^(\d+)\-(\d+)$/ ) {
+            foreach my $i ( $1 .. $2 ) {
+                push( @vlarray, $i );
+            }
+        }
+    }
+
+    return @vlarray;
+}
+
+sub int_vlan_nest {
+
+    my $running_config = shift or die;
+
+    # Store all nesting from running config separately
+    my $nest = "";
+    my %int;
+    foreach my $line ( split( /\n/, $running_config ) ) {
+        $line =~ s/\s+$//;
+        if ( $line =~ /^\S/ && $line =~ /interface Vlan/i ) {
+            $nest = $line;
+        }
+        $int{$nest} .= "$line\n"
+            if $nest ne "";
+    }
+
+    return %int;
+}
+
+sub open_file {
+
+    my $file = shift or die;
+
+    open my $FILE, '<', $file or die " Can't open '$file'";
+
+    my $config;
+
+    # Dump config into $config
+    while (<$FILE>) { $config .= $_ }
+    close $FILE;
+
+    return $config;
+}
+
+sub pass_check {
+
+    my $input = shift or die;
+
+    if ( $input =~ /FAIL/m ) {
+        return "FAIL,";
+    }
+    else {
+        return "PASS,";
+    }
+}
+
+sub interface_list {
+
+    my @int_list;
+    my $running_config = shift or die;
+
+    foreach my $line ( split( /\n/, $running_config ) ) {
+        if ( $line =~ /^(interface .*)/ ) {
+            next if $line =~ /Loopback/i;
+            push( @int_list, $1 );
+        }
+    }
+    return @int_list;
+}
+
+sub ios_config_all_interfaces {
+
+    my $new_config     = shift or die;
+    my $running_config = shift or die;
+    my @int_list       = shift or die;
+    my $new_int;
+    my $config_delta;
+
+    foreach (@int_list) {
+        $new_int = "$_\n$new_config";
+        $config_delta
+            .= &ios_config_nested_lines( $new_int, $running_config );
+    }
+
+    return $config_delta;
+}
+
+1;

--- a/policies/ios/policy_14_IOS_VStack
+++ b/policies/ios/policy_14_IOS_VStack
@@ -1,4 +1,4 @@
 !
 ! Policy 14 - IOS VStack
 !
-~ /no vstack/
+no vstack


### PR DESCRIPTION
- simplified timestamp creation
- enabled 'use strict' on all scripts
- reduced number of $diff and $output variable from 20+ to two in each policycheck 
- created simplified scripts for testing calls to ioslib.pm